### PR TITLE
feat: add shadcn/ui Button in yew

### DIFF
--- a/packages/yew/button/Cargo.toml
+++ b/packages/yew/button/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "shadcn-ui-yew-button"
+description = "Yew port of shadcn/ui button."
+publish = false
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+leptos.workspace = false
+tailwind_fuse.workspace = true

--- a/packages/yew/button/README.md
+++ b/packages/yew/button/README.md
@@ -1,0 +1,21 @@
+<p align="center">
+    <a href="../../../logo.svg">
+        <img src="../../../logo.svg" width="300" height="200" alt="Rust shadcn/ui Logo">
+    </a>
+</p>
+
+<h1 align="center">shadcn-ui-yew-button</h1>
+
+Displays a button or a component that looks like a button.
+
+[Rust shadcn/ui](https://github.com/RustForWeb/shadcn-ui) is a Rust port of [shadcn/ui](https://ui.shadcn.com/).
+
+## Documentation
+
+See [the Rust shadcn/ui book](https://shadcn-ui.rustforweb.org/) for documentation.
+
+## Rust For Web
+
+The Rust shadcn/ui project is part of the [Rust For Web](https://github.com/RustForWeb).
+
+[Rust For Web](https://github.com/RustForWeb) creates and ports web UI libraries for Rust. All projects are free and open source.

--- a/packages/yew/button/src/default.rs
+++ b/packages/yew/button/src/default.rs
@@ -1,0 +1,99 @@
+use std::rc::Rc;
+
+use tailwind_fuse::{tw_merge, AsTailwindClass};
+use yew::{prelude::*, virtual_dom::VTag};
+use yew_attrs::{attrs, Attrs};
+
+#[derive(Clone, PartialEq)]
+pub enum ButtonVariant {
+    Default,
+    Destructive,
+    Outline,
+    Secondary,
+    Ghost,
+    Link,
+}
+
+impl AsTailwindClass for ButtonVariant {
+    fn as_class(&self) -> &str {
+        match self {
+            ButtonVariant::Default => "bg-primary text-primary-foreground hover:bg-primary/90",
+            ButtonVariant::Destructive => {
+                "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            }
+            ButtonVariant::Outline => {
+                "border border-input bg-background hover:bg-accent hover:text-accent-foreground"
+            }
+            ButtonVariant::Secondary => {
+                "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+            }
+            ButtonVariant::Ghost => "hover:bg-accent hover:text-accent-foreground",
+            ButtonVariant::Link => "text-primary underline-offset-4 hover:underline",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub enum ButtonSize {
+    Default,
+    Sm,
+    Lg,
+    Icon,
+}
+
+impl AsTailwindClass for ButtonSize {
+    fn as_class(&self) -> &str {
+        match self {
+            ButtonSize::Default => "h-10 px-4 py-2",
+            ButtonSize::Sm => "h-9 rounded-md px-3",
+            ButtonSize::Lg => "h-11 rounded-md px-8",
+            ButtonSize::Icon => "h-10 w-10",
+        }
+    }
+}
+
+#[derive(Properties, PartialEq, Clone)]
+pub struct ButtonProps {
+    #[prop_or_default]
+    pub variant: Option<ButtonVariant>,
+    #[prop_or_default]
+    pub size: Option<ButtonSize>,
+    #[prop_or_default]
+    pub class: Option<String>,
+    #[prop_or_default]
+    pub node_ref: NodeRef,
+    #[prop_or_default]
+    pub attrs: Attrs,
+    pub children: Html,
+}
+
+#[function_component]
+pub fn Button(props: &ButtonProps) -> Html {
+    let base_class = "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+
+    let variant = props.variant.clone().unwrap_or(ButtonVariant::Default);
+    let size = props.size.clone().unwrap_or(ButtonSize::Default);
+    let class = props.class.clone().unwrap_or_default();
+
+    let combined_class = &tw_merge!(base_class.to_owned(), variant, size, &class);
+
+    let merged_attrs = use_memo(props.attrs.clone(), |attrs| {
+        attrs
+            .clone()
+            .merge(attrs! {
+               class={combined_class}
+            })
+            .expect("Attributes should be merged.")
+    });
+
+    let attrs = Rc::unwrap_or_clone(merged_attrs);
+
+    attrs
+        .new_vtag(
+            "button",
+            props.node_ref.clone(),
+            Default::default(),
+            props.children.clone(),
+        )
+        .into()
+}

--- a/packages/yew/button/src/lib.rs
+++ b/packages/yew/button/src/lib.rs
@@ -1,0 +1,8 @@
+//! Yew port of [shadcn/ui button](https://ui.shadcn.com/docs/components/button).
+//!
+//! Displays a button or a component that looks like a button.
+//!
+//! See [the Rust shadcn/ui book](https://shadcn-ui.rustforweb.org/components/button.html) for more documenation.
+
+pub mod default;
+pub mod new_york;

--- a/packages/yew/button/src/new_york.rs
+++ b/packages/yew/button/src/new_york.rs
@@ -1,0 +1,99 @@
+use std::rc::Rc;
+
+use tailwind_fuse::{tw_merge, AsTailwindClass};
+use yew::{prelude::*, virtual_dom::VTag};
+use yew_attrs::{attrs, Attrs};
+
+#[derive(Clone, PartialEq)]
+pub enum ButtonVariant {
+    Default,
+    Destructive,
+    Outline,
+    Secondary,
+    Ghost,
+    Link,
+}
+
+impl AsTailwindClass for ButtonVariant {
+    fn as_class(&self) -> &str {
+        match self {
+            ButtonVariant::Default => "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+            ButtonVariant::Destructive => {
+                "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90"
+            }
+            ButtonVariant::Outline => {
+                "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground"
+            }
+            ButtonVariant::Secondary => {
+                "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80"
+            }
+            ButtonVariant::Ghost => "hover:bg-accent hover:text-accent-foreground",
+            ButtonVariant::Link => "text-primary underline-offset-4 hover:underline",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub enum ButtonSize {
+    Default,
+    Sm,
+    Lg,
+    Icon,
+}
+
+impl AsTailwindClass for ButtonSize {
+    fn as_class(&self) -> &str {
+        match self {
+            ButtonSize::Default => "h-9 px-4 py-2",
+            ButtonSize::Sm => "h-8 rounded-md px-3 text-xs",
+            ButtonSize::Lg => "h-10 rounded-md px-8",
+            ButtonSize::Icon => "h-9 w-9",
+        }
+    }
+}
+
+#[derive(Properties, PartialEq, Clone)]
+pub struct ButtonProps {
+    #[prop_or_default]
+    pub variant: Option<ButtonVariant>,
+    #[prop_or_default]
+    pub size: Option<ButtonSize>,
+    #[prop_or_default]
+    pub class: Option<String>,
+    #[prop_or_default]
+    pub node_ref: NodeRef,
+    #[prop_or_default]
+    pub attrs: Attrs,
+    pub children: Html,
+}
+
+#[function_component]
+pub fn Button(props: &ButtonProps) -> Html {
+    let base_class = "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50";
+
+    let variant = props.variant.clone().unwrap_or(ButtonVariant::Default);
+    let size = props.size.clone().unwrap_or(ButtonSize::Default);
+    let class = props.class.clone().unwrap_or_default();
+
+    let combined_class = &tw_merge!(base_class.to_owned(), variant, size, &class);
+
+    let merged_attrs = use_memo(props.attrs.clone(), |attrs| {
+        attrs
+            .clone()
+            .merge(attrs! {
+               class={combined_class}
+            })
+            .expect("Attributes should be merged.")
+    });
+
+    let attrs = Rc::unwrap_or_clone(merged_attrs);
+
+    attrs
+        .new_vtag(
+            "button",
+            props.node_ref.clone(),
+            Default::default(),
+            props.children.clone(),
+        )
+        .into()
+}


### PR DESCRIPTION
Just starting the yew shadcn/ui button implementation here.

I have an issue with `<button {..attrs}` in yew, I hope I will find a workaround